### PR TITLE
Use v2.1.1 of the Android SDK.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.0'
-    compile 'io.keen:keen-client-api-android:2.1.0@aar'
+    compile 'io.keen:keen-client-api-android:2.1.1@aar'
 }


### PR DESCRIPTION
Update `app/build.gradle` to point to the recently released v2.1.1 of the SDK.