### PR TITLE
Android Studio 1.2 compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
 }

--- a/app/src/main/java/io/keen/client/android/example/MyActivity.java
+++ b/app/src/main/java/io/keen/client/android/example/MyActivity.java
@@ -1,6 +1,5 @@
 package io.keen.client.android.example;
 
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;

--- a/app/src/main/java/io/keen/client/android/example/MyActivity.java
+++ b/app/src/main/java/io/keen/client/android/example/MyActivity.java
@@ -14,7 +14,9 @@ import io.keen.client.java.KeenClient;
 import io.keen.client.java.KeenLogging;
 import io.keen.client.java.KeenProject;
 
-public class MyActivity extends ActionBarActivity {
+import android.app.Activity;
+
+public class MyActivity extends Activity {
 
     private static int clickNumber = 0;
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:1.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Thu May 14 12:44:26 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
Android Studio 1.2 compatibility requires Gradle upgrade. Also,
MyActivity should extend from Activity, since ActionBarActivity now
requires AppCompat theme.